### PR TITLE
Minor fix due to MongoMapper refactor which remove InstanceMethods

### DIFF
--- a/lib/mm-optimistic_locking.rb
+++ b/lib/mm-optimistic_locking.rb
@@ -3,6 +3,6 @@ require 'mongo_mapper'
 require File.expand_path("mongo_mapper/stale_document_error", File.dirname(__FILE__))
 require File.expand_path("mongo_mapper/plugins/optimistic_locking", File.dirname(__FILE__))
 
-MongoMapper::Plugins::Querying::InstanceMethods.class_eval do
+MongoMapper::Plugins::Querying.class_eval do
   include MongoMapper::Plugins::OptimisticLocking::QueryingInterceptor
 end


### PR DESCRIPTION
See this commit on MongoMapper for when this broke:
https://github.com/jnunemaker/mongomapper/commit/d2333d944ce6ae59ecab3c45e25bbed261f8180e
